### PR TITLE
Fix compiler warnings.

### DIFF
--- a/wayfire/touch/touch.hpp
+++ b/wayfire/touch/touch.hpp
@@ -77,12 +77,12 @@ struct gesture_event_t
     /** type of the event */
     gesture_event_type_t type;
     /** timestamp of the event in milliseconds */
-    uint32_t time;
+    uint32_t time{};
     /** finger id which the event is about */
-    int32_t finger;
+    int32_t finger{};
 
     /** coordinates of the finger */
-    point_t pos;
+    point_t pos{};
 };
 
 /**


### PR DESCRIPTION
This change gets rid of the warnings (while compiling wayfire):

[70/476] Compiling C++ object subprojects/wf-touch/libwftouch.a.p/src_touch.cpp.o ../../../../github/wayfire/wayfire.git/subprojects/wf-touch/src/touch.cpp: In lambda function: ../../../../github/wayfire/wayfire.git/subprojects/wf-touch/src/touch.cpp:103:72: warning: missing initializer for member ‘wf::touch::gesture_event_t::time’ [-Wmissing-field-initializers]
  103 |                 update_state(gesture_event_t{.type = EVENT_TYPE_TIMEOUT});
      |                                                                        ^
../../../../github/wayfire/wayfire.git/subprojects/wf-touch/src/touch.cpp:103:72: warning: missing initializer for member ‘wf::touch::gesture_event_t::finger’ [-Wmissing-field-initializers]
../../../../github/wayfire/wayfire.git/subprojects/wf-touch/src/touch.cpp:103:72: warning: missing initializer for member ‘wf::touch::gesture_event_t::pos’ [-Wmissing-field-initializers]

For `.type` EVENT_TYPE_TIMEOUT it is OK to have the members `.time`, `.finger` and `.pos` undefined, or set to zero as with this patch, because they are not used.

Nevertheless, the warning is annoying; so it is better to have a default initialization for them.